### PR TITLE
Added OrderBy when iterating over tags and keys

### DIFF
--- a/src/ARI/Commands/InventoryCommand.cs
+++ b/src/ARI/Commands/InventoryCommand.cs
@@ -41,7 +41,8 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
             await writer.AddFrontmatter(
                 modified,
                 $"Tenant {tenant.DisplayName} ({tenant.TenantId})",
-                1
+                1,
+                settings
             );
 
             await writer.AddTenantOverview(tenant);
@@ -51,7 +52,8 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
             await writer.AddFrontmatter(
                 modified,
                 "Azure Inventory",
-                1
+                1,
+                settings
             );
         }
 
@@ -72,7 +74,8 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
                 await writer.AddFrontmatter(
                     modified,
                     $"Subscription {subscription.DisplayName} ({subscription.TenantId})",
-                    subscription.Order
+                    subscription.Order,
+                    settings
                     );
 
                 await writer.AddSubscriptionOverview(subscription);
@@ -97,7 +100,8 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
                         await writer.AddFrontmatter(
                             modified,
                             $"Resource Group {resourceGroup.Name} ({subscription.SubscriptionId})",
-                            resourceGroup.Order
+                            resourceGroup.Order,
+                            settings
                             );
 
                         await writer.AddResourceGroupOverview(resourceGroup);
@@ -157,7 +161,8 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
                                 await writer.AddFrontmatter(
                                     modified,
                                     $"Resource {resource.Name} ({subscription.SubscriptionId})",
-                                    resource.Order
+                                    resource.Order,
+                                    settings
                                     );
 
                                 await writer.AddResourceOverview(resource);

--- a/src/ARI/Commands/Settings/InventorySettings.cs
+++ b/src/ARI/Commands/Settings/InventorySettings.cs
@@ -22,4 +22,10 @@ public class InventorySettings : CommandSettings
 
     [CommandOption("--markdown-name")]
     public string MarkdownName { get; set; } = "index";
+
+    [CommandOption("--avoid-generating-diffs")]
+    public bool AvoidGeneratingDiffs { get; set; }
+
+
+
 }

--- a/src/ARI/Extensions/TextWriterMarkdownExtensions.cs
+++ b/src/ARI/Extensions/TextWriterMarkdownExtensions.cs
@@ -115,7 +115,7 @@ public static class TextWriterMarkdownExtensions
             return;
         }
 
-        foreach (var (key, value) in tags)
+        foreach (var (key, value) in tags.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
         {
             await writer.WriteLineAsync(
                 FormattableString.Invariant(
@@ -146,7 +146,7 @@ public static class TextWriterMarkdownExtensions
                )
            );
 
-        foreach (var (key, value) in children)
+        foreach (var (key, value) in children.OrderBy(v => v.PublicId, StringComparer.OrdinalIgnoreCase))
         {
             await writer.WriteLineAsync(
                 FormattableString.Invariant(

--- a/src/ARI/Extensions/TextWriterMarkdownExtensions.cs
+++ b/src/ARI/Extensions/TextWriterMarkdownExtensions.cs
@@ -15,20 +15,37 @@ public static class TextWriterMarkdownExtensions
         this TextWriter writer,
         DateTimeOffset lastUpdateTime,
         string summary,
-        int order)
+        int order,
+        InventorySettings settings)
     {
-        await writer.WriteLineAsync(
-            FormattableString.Invariant(
-                    $$"""
-                    ---
-                    summary: {{summary}}
-                    modifiedby: ARI
-                    modified: {{lastUpdateTime:yyyy-MM-dd HH:mm}}
-                    order: {{order}}
-                    ---
-                    """
-                )
-            );
+        if (settings.AvoidGeneratingDiffs)
+        {
+            await writer.WriteLineAsync(
+                FormattableString.Invariant(
+                        $$"""
+                        ---
+                        summary: {{summary}}
+                        modifiedby: ARI
+                        modified: {{lastUpdateTime:yyyy-MM-dd HH:mm}}
+                        order: {{order}}
+                        ---
+                        """
+                    )
+                );
+        }
+        else
+        {
+            await writer.WriteLineAsync(
+                FormattableString.Invariant(
+                        $$"""
+                        ---
+                        summary: {{summary}}
+                        modifiedby: ARI
+                        ---
+                        """
+                    )
+                );
+        }
     }
 
     public static async Task AddTenantOverview(


### PR DESCRIPTION
I think ordering on keys could help eliminate fake diffs because of random shuffling. Perhaps the original order is important to preserve but I coudn't think of a reason why