### PR TITLE
Update package versions and remove unused code

### DIFF
--- a/build/helpers.cs
+++ b/build/helpers.cs
@@ -37,25 +37,3 @@ public static partial class CakeTaskBuilderExtensions
     }
 
 }
-
-public class FilePathJsonConverter : PathJsonConverter<FilePath>
-{
-    protected override FilePath ConvertFromString(string value) => FilePath.FromString(value);
-}
-
-public abstract class PathJsonConverter<TPath> : System.Text.Json.Serialization.JsonConverter<TPath> where TPath : Cake.Core.IO.Path
-{
-    public override TPath Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
-    {
-        var value = reader.GetString();
-
-        return value is null ? null : ConvertFromString(value);
-    }
-
-    public override void Write(System.Text.Json.Utf8JsonWriter writer, TPath value, System.Text.Json.JsonSerializerOptions options)
-    {
-        writer.WriteStringValue(value.FullPath);
-    }
-
-    protected abstract TPath ConvertFromString(string value);
-}

--- a/src/ARI.TestWeb/ARI.TestWeb.csproj
+++ b/src/ARI.TestWeb/ARI.TestWeb.csproj
@@ -12,17 +12,17 @@
   <ItemGroup>
     <PackageReference Include="Devlead.Statiq" Version="2025.9.10.150" />
     <PackageReference Include="Statiq.Web" Version="1.0.0-beta.60" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.1" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.2" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.2" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ARI.Tests/ARI.Tests.csproj
+++ b/src/ARI.Tests/ARI.Tests.csproj
@@ -70,7 +70,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Verify.NUnit" Version="31.9.4" />
-    <PackageReference Include="Devlead.Testing.MockHttp" Version="2025.12.16.528" />
+    <PackageReference Include="Devlead.Testing.MockHttp" Version="2026.1.14.568" />
     <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>

--- a/src/ARI/ARI.csproj
+++ b/src/ARI/ARI.csproj
@@ -41,12 +41,12 @@
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1 " Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.12" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="'$(TargetFramework)' != 'net10.0'" />
-    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2025.12.17.441" />
+    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.1.14.460" />
     <PackageReference Include="Cake.Common" Version="6.0.0" />
-    <PackageReference Include="Devlead.Console" Version="2025.12.17.530" />
+    <PackageReference Include="Devlead.Console" Version="2026.1.14.558" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Remove unused FilePathJsonConverter and PathJsonConverter classes
- Update System.* packages to 10.0.2 in ARI.TestWeb
- Update Devlead.Testing.MockHttp to 2026.1.14.568
- Update Microsoft.Extensions.Http: 9.0.11 → 9.0.12, 10.0.1 → 10.0.2
- Update Cake.Bridge.DependencyInjection to 2026.1.14.460
- Update Devlead.Console to 2026.1.14.558