### PR TITLE
chore(ARI): bump Microsoft.Extensions.Http and Devlead.Console

### DIFF
--- a/src/ARI.TestWeb/ARI.TestWeb.csproj
+++ b/src/ARI.TestWeb/ARI.TestWeb.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 

--- a/src/ARI.Tests/Unit/Commands/InventoryCommandTests.cs
+++ b/src/ARI.Tests/Unit/Commands/InventoryCommandTests.cs
@@ -44,7 +44,7 @@ public class InventoryCommandTests
                                 )
             );
 
-        var command = new InventoryCommand(
+        ICommand<InventorySettings> command = new InventoryCommand(
             cakeContext,
             logger,
             tenantService,

--- a/src/ARI/ARI.csproj
+++ b/src/ARI/ARI.csproj
@@ -42,11 +42,11 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1 " Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" Condition="'$(TargetFramework)' != 'net10.0'" />
     <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.5.18.616" />
     <PackageReference Include="Cake.Common" Version="6.1.0" />
-    <PackageReference Include="Devlead.Console" Version="2026.2.11.575" />
+    <PackageReference Include="Devlead.Console" Version="2026.5.15.709" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ARI/Commands/InventoryCommand.cs
+++ b/src/ARI/Commands/InventoryCommand.cs
@@ -22,7 +22,7 @@ public class InventoryCommand : AsyncCommand<InventorySettings>
         { "Has-tags", "false" }
     };
 
-    public override async Task<int> ExecuteAsync(CommandContext context, InventorySettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, InventorySettings settings, CancellationToken cancellationToken)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var modified = DateTimeOffset.UtcNow;


### PR DESCRIPTION
- ARI.TestWeb: pin Microsoft.Rest.ClientRuntime to 2.3.24 (< 3.0.0 required by
  Microsoft.Azure.Search via Devlead.Statiq)
- ARI: bump Microsoft.Extensions.Http (net10.0) to 10.0.8 and Devlead.Console to
  2026.5.15.709
- InventoryCommand: make ExecuteAsync protected override per updated command base
- InventoryCommandTests: declare command as ICommand<InventorySettings>